### PR TITLE
fix: adding network policy to deployment

### DIFF
--- a/openshift.deploy.yml
+++ b/openshift.deploy.yml
@@ -205,3 +205,45 @@ objects:
       tls:
         termination: edge
         insecureEdgeTerminationPolicy: Redirect
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: allow-from-openshift-ingress
+      labels:
+        template: openshift-${ZONE}
+    spec:
+      podSelector: { }
+      ingress:
+        - from:
+            - namespaceSelector:
+                matchLabels:
+                  network.openshift.io/policy-group: ingress
+      policyTypes:
+        - Ingress
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: allow-same-namespace
+      labels:
+        template: quickstart-network-security-policy
+    spec:
+      podSelector: { }
+      ingress:
+        - from:
+            - podSelector: { }
+      policyTypes:
+        - Ingress
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: allow-traffic-from-gateway-to-your-api
+    spec:
+      podSelector:
+        matchLabels:
+          app: ${NAME}-${ZONE}
+      ingress:
+        - from:
+            - namespaceSelector:
+                matchLabels:
+                  environment: ${ZONE}
+                  name: 264e6f


### PR DESCRIPTION
# Description

Adding network policy to deployment to allow route from GWA

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually through editing the network policy

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

## Further comments

This will create a policy for a non-existing exposing environment (dev) but it can be useful in the future.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[API](https://nr-forest-client-api-104-backend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-forest-client-api/actions/workflows/merge-main.yml)