### PR TITLE
Switch from Dependabot to Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: daily

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -221,6 +221,7 @@ jobs:
     env:
       COMPONENT: backend
       ZONE: ${{ github.event.number }}
+      DOMAIN: apps.silver.devops.gov.bc.ca
     needs:
       - deploy-dev
     environment:


### PR DESCRIPTION
Vault and Dependabot don't get along.  This PR switches to using Renovate, with the config for that in bcgov/renovate and another PR incoming.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[API](https://nr-forest-client-api-126-backend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-forest-client-api/actions/workflows/merge-main.yml)