### PR TITLE
Add resource allocations for initContainers

### DIFF
--- a/openshift.deploy.yml
+++ b/openshift.deploy.yml
@@ -118,7 +118,7 @@ objects:
         spec:
           volumes:
             - name: certs
-              emptyDir: { }
+              emptyDir: {}
           initContainers:
             - name: ${NAME}-init
               image: ${REGISTRY}/bcgov/${NAME}/init:${ZONE}
@@ -131,6 +131,13 @@ objects:
                       key: oracle-host
                 - name: ORACLEDB_PORT
                   value: "1543"
+              resources:
+                limits:
+                  cpu: ${CPU_LIMIT}
+                  memory: ${MEMORY_LIMIT}
+                requests:
+                  cpu: ${CPU_REQUEST}
+                  memory: ${MEMORY_REQUEST}
               volumeMounts:
                 - mountPath: /cert
                   name: certs
@@ -243,7 +250,7 @@ objects:
       labels:
         template: openshift-${ZONE}
     spec:
-      podSelector: { }
+      podSelector: {}
       ingress:
         - from:
             - namespaceSelector:
@@ -258,10 +265,10 @@ objects:
       labels:
         template: quickstart-network-security-policy
     spec:
-      podSelector: { }
+      podSelector: {}
       ingress:
         - from:
-            - podSelector: { }
+            - podSelector: {}
       policyTypes:
         - Ingress
   - apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
Testing out resource allocations for initContainers.  This previously hasn't been required.  ...or even considered.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[API](https://nr-forest-client-api-144-backend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-forest-client-api/actions/workflows/merge-main.yml)