### PR TITLE
chore(ci): clean up old init job in pr-close.yml

### DIFF
--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -34,15 +34,12 @@ jobs:
     name: Image Promotions
     if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        component: [ api, init ]
     steps:
-      - name: Promoting ${{ matrix.component }}
+      - name: Promoting API
         uses: shrink/actions-docker-registry-tag@v3
         with:
           registry: ghcr.io
-          repository: ${{ github.repository }}/${{ matrix.component }}
+          repository: ${{ github.repository }}/api
           target: ${{ github.event.number }}
           tags: test
 

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -32,7 +32,7 @@ jobs:
   # If merged into main, then handle any image promotions
   image-promotions:
     name: Image Promotions
-    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    # if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-22.04
     steps:
       - name: Promoting API
@@ -48,7 +48,7 @@ jobs:
   merge-notification:
     name: Merge Notification
     runs-on: ubuntu-22.04
-    # if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     steps:
       - name: Pre-merge update
         uses: mshick/add-pr-comment@v2

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -48,7 +48,7 @@ jobs:
   merge-notification:
     name: Merge Notification
     runs-on: ubuntu-22.04
-    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    # if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     steps:
       - name: Pre-merge update
         uses: mshick/add-pr-comment@v2


### PR DESCRIPTION
There's a leftover from the old API package causing errors.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[API](https://nr-forest-client-api-206-backend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-forest-client-api/actions/workflows/merge-main.yml)