### PR TITLE
chore: Fixed GitHub Actions Workflow

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -50,7 +50,6 @@ jobs:
           oc_server: ${{ secrets.OC_SERVER }}
           oc_token: ${{ secrets.OC_TOKEN }}
           overwrite: true
-          verification_path: /health
           oc_version: "4.13"
           parameters:
             -p ORACLEDB_USER=${{ secrets.ORACLEDB_USERNAME }}
@@ -95,7 +94,6 @@ jobs:
           oc_server: ${{ secrets.OC_SERVER }}
           oc_token: ${{ secrets.OC_TOKEN }}
           overwrite: true
-          verification_path: /health
           oc_version: "4.13"
           parameters:
             -p ORACLEDB_USER=${{ secrets.ORACLEDB_USERNAME }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -56,8 +56,8 @@ jobs:
           message: |
             # Current changelog
             ${{ steps.changelog.outputs.clean_changelog }}
-          comment_tag: "# Current changelog"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          comment-tag: "# Current changelog"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   pr-greeting:
     name: Greeting

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -113,7 +113,6 @@ jobs:
           oc_token: ${{ secrets.OC_TOKEN }}
           overwrite: true
           oc_version: "4.13"
-          verification_path: /health
           parameters:
             -p ORACLEDB_USER=${{ secrets.ORACLEDB_USERNAME }}
             -p ORACLEDB_PASSWORD=${{ secrets.ORACLEDB_PASSWORD }}


### PR DESCRIPTION
Fixed input parameters in GitHub Actions workflow:

1. Corrected comment_tag to comment-tag.
2. Replaced GITHUB_TOKEN with github-token for consistency with the action's expected inputs.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[API](https://nr-forest-client-api-302-api.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-forest-client-api/actions/workflows/merge-main.yml)