### PR TITLE
feat(waste-plus-127): updating search by numbers

### DIFF
--- a/src/main/java/ca/bc/gov/api/oracle/legacy/controller/ClientSearchController.java
+++ b/src/main/java/ca/bc/gov/api/oracle/legacy/controller/ClientSearchController.java
@@ -99,18 +99,19 @@ public class ClientSearchController {
       Integer size,
 
       @Parameter(description = "Id of the client you're searching", example = "00000001")
-      @RequestParam(value = "id", required = false)
+      @RequestParam(value = "id")
       List<String> id,
+
+      @Parameter(description = "Name of the client you want to filter by", example = "BOND")
+      @RequestParam(value = "name", required = false)
+      String name,
 
       ServerHttpResponse serverResponse
   ) {
     log.info("Searching for clients with ids {}", id);
-    return clientSearchService
-        .searchClientByQuery(
-            clientSearchService.searchById(id),
-            page,
-            size
-        )
+    return
+        clientSearchService
+            .searchByIdsAndName(id, name,page,size)
         .doOnNext(client -> log.info("Found client with id {}", client.getClientNumber()))
         .doOnNext(dto -> serverResponse.getHeaders()
             .putIfAbsent(ApplicationConstants.X_TOTAL_COUNT, List.of(dto.getCount().toString())));

--- a/src/main/java/ca/bc/gov/api/oracle/legacy/entity/ForestClientCountEntity.java
+++ b/src/main/java/ca/bc/gov/api/oracle/legacy/entity/ForestClientCountEntity.java
@@ -1,0 +1,68 @@
+package ca.bc.gov.api.oracle.legacy.entity;
+
+
+import static ca.bc.gov.api.oracle.legacy.ApplicationConstants.INDIVIDUAL;
+import static ca.bc.gov.api.oracle.legacy.ApplicationConstants.ORACLE_ATTRIBUTE_SCHEMA;
+
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.With;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Transient;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Data
+@With
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "FOREST_CLIENT", schema = ORACLE_ATTRIBUTE_SCHEMA)
+public class ForestClientCountEntity {
+
+  @Id
+  @Column("CLIENT_NUMBER")
+  private String clientNumber;
+
+  @Column("CLIENT_NAME")
+  private String clientName;
+
+  @Column("LEGAL_FIRST_NAME")
+  private String legalFirstName;
+
+  @Column("LEGAL_MIDDLE_NAME")
+  private String legalMiddleName;
+
+  @Column("CLIENT_STATUS_CODE")
+  private String clientStatusCode;
+
+  @Column("CLIENT_TYPE_CODE")
+  private String clientTypeCode;
+
+  @Column("CLIENT_ID_TYPE_CODE")
+  private String clientIdTypeCode;
+
+  @Column("CLIENT_ACRONYM")
+  private String clientAcronym;
+
+  @Column("COUNT")
+  private Long count;
+
+  @Transient
+  public String getName() {
+    if (Objects.equals(this.clientTypeCode, INDIVIDUAL)) {
+      return Stream.of(this.legalFirstName, this.legalMiddleName, this.clientName)
+          .filter(Objects::nonNull)
+          .collect(Collectors.joining(" "));
+    } else {
+      return this.clientName;
+    }
+  }
+
+}
+

--- a/src/main/java/ca/bc/gov/api/oracle/legacy/repository/ForestClientRepository.java
+++ b/src/main/java/ca/bc/gov/api/oracle/legacy/repository/ForestClientRepository.java
@@ -1,7 +1,9 @@
 package ca.bc.gov.api.oracle.legacy.repository;
 
 import ca.bc.gov.api.oracle.legacy.dto.SearchNumberScoreProjection;
+import ca.bc.gov.api.oracle.legacy.entity.ForestClientCountEntity;
 import ca.bc.gov.api.oracle.legacy.entity.ForestClientEntity;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.repository.query.ReactiveQueryByExampleExecutor;
@@ -29,29 +31,19 @@ public interface ForestClientRepository extends ReactiveCrudRepository<ForestCli
       String clientName);
 
 
-  @Query(value = """
-    SELECT
-      CLIENT_NUMBER,
-      (
-        CASE WHEN CLIENT_ACRONYM = :acronym THEN 800 ELSE 0 END +
-        CASE WHEN CLIENT_NUMBER = :clientNumber THEN 1000 ELSE 0 END +
-        UTL_MATCH.JARO_WINKLER_SIMILARITY(TRIM(COALESCE(LEGAL_FIRST_NAME || ' ', '') 
-              || TRIM(COALESCE(LEGAL_MIDDLE_NAME || ' ', '')) 
-              || COALESCE(CLIENT_NAME, '')), :clientName)
-      ) AS score
-    FROM THE.FOREST_CLIENT
-    WHERE
-      UTL_MATCH.JARO_WINKLER_SIMILARITY(TRIM(COALESCE(LEGAL_FIRST_NAME || ' ', '') 
-            || TRIM(COALESCE(LEGAL_MIDDLE_NAME || ' ', '')) 
-            || COALESCE(CLIENT_NAME, '')), :clientName) >= 80
-      OR CLIENT_ACRONYM = :acronym
-      OR CLIENT_NUMBER = :clientNumber
-    ORDER BY score DESC
-    OFFSET :offset ROWS FETCH NEXT :size ROWS ONLY""")
+  @Query(value = QueryConstants.SEARCH_NUMBER_NAME_ACRONYM)
 	Flux<SearchNumberScoreProjection> searchNumberByNameAcronymNumber(
       String clientName,
       String acronym,
       String clientNumber,
       long offset,
       int size);
+
+  @Query(value = QueryConstants.SEARCH_BY_NUMBER_AND_NAME)
+  Flux<ForestClientCountEntity> searchByIdsAndName(
+      List<String> clientNumbers,
+      String clientName,
+      long offset,
+      int size
+  );
 }

--- a/src/main/java/ca/bc/gov/api/oracle/legacy/repository/QueryConstants.java
+++ b/src/main/java/ca/bc/gov/api/oracle/legacy/repository/QueryConstants.java
@@ -1,0 +1,49 @@
+package ca.bc.gov.api.oracle.legacy.repository;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class QueryConstants {
+
+  public static final String SEARCH_NUMBER_NAME_ACRONYM = """
+      SELECT
+        CLIENT_NUMBER,
+        (
+          CASE WHEN CLIENT_ACRONYM = :acronym THEN 800 ELSE 0 END +
+          CASE WHEN CLIENT_NUMBER = :clientNumber THEN 1000 ELSE 0 END +
+          UTL_MATCH.JARO_WINKLER_SIMILARITY(TRIM(COALESCE(LEGAL_FIRST_NAME || ' ', '') 
+                || TRIM(COALESCE(LEGAL_MIDDLE_NAME || ' ', '')) 
+                || COALESCE(CLIENT_NAME, '')), :clientName)
+        ) AS score
+      FROM THE.FOREST_CLIENT
+      WHERE
+        UTL_MATCH.JARO_WINKLER_SIMILARITY(TRIM(COALESCE(LEGAL_FIRST_NAME || ' ', '') 
+              || TRIM(COALESCE(LEGAL_MIDDLE_NAME || ' ', '')) 
+              || COALESCE(CLIENT_NAME, '')), :clientName) >= 80
+        OR CLIENT_ACRONYM = :acronym
+        OR CLIENT_NUMBER = :clientNumber
+      ORDER BY score DESC
+      OFFSET :offset ROWS FETCH NEXT :size ROWS ONLY""";
+
+  public static final String SEARCH_BY_NUMBER_AND_NAME = """
+      WITH ResultSet AS (
+        SELECT
+          *
+        FROM THE.FOREST_CLIENT
+        WHERE
+          CLIENT_NUMBER IN(:clientNumber)
+          AND
+          (
+            NVL(:clientName,'NOVALUE') = 'NOVALUE' OR
+                UTL_MATCH.JARO_WINKLER_SIMILARITY(TRIM(COALESCE(LEGAL_FIRST_NAME || ' ', '')
+                      || TRIM(COALESCE(LEGAL_MIDDLE_NAME || ' ', ''))
+                      || COALESCE(CLIENT_NAME, '')), :clientName) >= 80
+            )
+        )
+        SELECT
+        COUNT(*) OVER() AS COUNT,
+        rs.*
+        FROM ResultSet rs
+        OFFSET :offset ROWS FETCH NEXT :size ROWS ONLY""";
+}

--- a/src/main/java/ca/bc/gov/api/oracle/legacy/service/ClientSearchService.java
+++ b/src/main/java/ca/bc/gov/api/oracle/legacy/service/ClientSearchService.java
@@ -19,6 +19,7 @@ import org.springframework.data.r2dbc.core.R2dbcEntityTemplate;
 import org.springframework.data.relational.core.query.Criteria;
 import org.springframework.data.relational.core.query.Query;
 import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -152,6 +153,34 @@ public class ClientSearchService {
             .collectList()
             .map(this::searchById);
 
+  }
+  /**
+   * Searches for clients based on the provided list of IDs and an optional name filter. The search
+   * results are paginated according to the specified page number and size.
+   *
+   * @param id   A list of client IDs to search for.
+   * @param name An optional name filter to refine the search results.
+   * @param page The page number to retrieve (0-based).
+   * @param size The number of results per page.
+   * @return A Flux stream of matching clients as ClientPublicViewDto objects.
+   * @implNote This method is currently a placeholder and returns null. The implementation should
+   * include logic to perform the search using the provided parameters and return the appropriate
+   * results.
+   */
+  public Flux<ClientPublicViewDto> searchByIdsAndName(List<String> id, String name, Integer page, Integer size) {
+    log.info("Searching by ids {} and name {}, page: {}, size: {}", id, name, page, size);
+
+    String searchName = StringUtils.isNotBlank(name) ? name.toUpperCase() : null;
+    List<String> searchIds = !CollectionUtils.isEmpty(id) ? id : List.of();
+
+    return forestClientRepository
+        .searchByIdsAndName(
+            searchIds,
+            searchName,
+            (page * size.longValue()),
+            size
+        )
+        .map(ClientMapper::mapEntityToDto);
   }
 
   private String checkClientNumber(String clientNumber) {

--- a/src/main/java/ca/bc/gov/api/oracle/legacy/util/ClientMapper.java
+++ b/src/main/java/ca/bc/gov/api/oracle/legacy/util/ClientMapper.java
@@ -2,6 +2,7 @@ package ca.bc.gov.api.oracle.legacy.util;
 
 import ca.bc.gov.api.oracle.legacy.dto.ClientPublicViewDto;
 import ca.bc.gov.api.oracle.legacy.dto.ClientViewDto;
+import ca.bc.gov.api.oracle.legacy.entity.ForestClientCountEntity;
 import ca.bc.gov.api.oracle.legacy.entity.ForestClientEntity;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -34,6 +35,20 @@ public class ClientMapper {
         .clientStatusCode(clientEntity.getClientStatusCode())
         .clientTypeCode(clientEntity.getClientTypeCode())
         .acronym(clientEntity.getClientAcronym())
+        .build();
+  }
+
+  public static ClientPublicViewDto mapEntityToDto(ForestClientCountEntity clientEntity) {
+    return ClientPublicViewDto
+        .builder()
+        .clientNumber(clientEntity.getClientNumber())
+        .clientName(clientEntity.getClientName())
+        .legalFirstName(clientEntity.getLegalFirstName())
+        .legalMiddleName(clientEntity.getLegalMiddleName())
+        .clientStatusCode(clientEntity.getClientStatusCode())
+        .clientTypeCode(clientEntity.getClientTypeCode())
+        .acronym(clientEntity.getClientAcronym())
+        .count(clientEntity.getCount())
         .build();
   }
 

--- a/src/test/java/ca/bc/gov/api/oracle/legacy/controller/ClientSearchControllerIntegrationTest.java
+++ b/src/test/java/ca/bc/gov/api/oracle/legacy/controller/ClientSearchControllerIntegrationTest.java
@@ -2,6 +2,7 @@ package ca.bc.gov.api.oracle.legacy.controller;
 
 import ca.bc.gov.api.oracle.legacy.AbstractTestContainerIntegrationTest;
 import ca.bc.gov.api.oracle.legacy.dto.ClientPublicViewDto;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
@@ -21,7 +22,7 @@ class ClientSearchControllerIntegrationTest extends AbstractTestContainerIntegra
   @ParameterizedTest
   @MethodSource("searchById")
   @DisplayName("Search clients by ID")
-  void shouldSearchClientsById(Integer returnSize, Object[] ids) {
+  void shouldSearchClientsById(Integer returnSize, List<String> ids) {
 
     System.out.printf("returnSize: %d, ids: %s%n", returnSize, ids);
 
@@ -74,10 +75,9 @@ class ClientSearchControllerIntegrationTest extends AbstractTestContainerIntegra
 
   private static Stream<Arguments> searchById() {
     return Stream.of(
-        Arguments.of(1, new Object[]{"00000001"}),
-        Arguments.of(1, new Object[]{"00000001", "1", "4"}),
-        Arguments.of(0, new Object[]{"00000999"}),
-        Arguments.of(0, null)
+        Arguments.of(1, List.of("00000001")),
+        Arguments.of(1, List.of("00000001", "1", "4")),
+        Arguments.of(0, List.of("00000999"))
     );
   }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Search by number will require the ids to be mandatory, otherwise it is useless. Also added an optional name field to be used as a filter as well. This allows the results to be filtered out, while still being applied to the selected ids only.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[API](https://nr-forest-client-api-374-api.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-forest-client-api/actions/workflows/merge-main.yml)