### PR TITLE
chore: bump springdoc-openapi-starter-webflux-ui and spring-web versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
     <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
-      <version>2.8.17</version>
+      <version>3.0.3</version>
     </dependency>
 
     <dependency>
@@ -251,7 +251,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-web</artifactId>
-        <version>6.2.18</version>
+        <version>7.0.7</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.database.jdbc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
     <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
-      <version>3.0.3</version>
+      <version>2.8.17</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
**Summary**

	•  What: Update OpenAPI / Spring Web versions in pom.xml:
	•  Bump org.springdoc:springdoc-openapi-starter-webflux-ui to 3.0.3.
	•  Bump org.springframework:spring-web to 7.0.7 (managed in dependencyManagement).
	•  Why: Bring OpenAPI tooling and Spring web dependency to the target versions for bug fixes, compatibility with other libs, and up-to-date features.

**Background**

	•  Keeping springdoc up-to-date ensures the latest OpenAPI generation and UI fixes for WebFlux.
	•  Aligning spring-web version in dependency management ensures consistent Spring Web runtime artifacts and avoids transitive-version drift.

Files changed

	•  pom.xml — dependency and dependencyManagement sections.

**Concrete changes**

	•  Dependencies
	•  org.springdoc:springdoc-openapi-starter-webflux-ui:
		•  Before: 2.8.17
		•  After: 3.0.3
		•  Location: dependencies block (explicit version declared)

	•  Dependency management
	•  org.springframework:spring-web:
		•  Before: 6.2.18
		•  After: 7.0.7
		•  Location: dependencyManagement -> dependencies

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[API](https://nr-forest-client-api-565-api.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-forest-client-api/actions/workflows/merge-main.yml)